### PR TITLE
[BASE-1355] Add 'Etag' header to CORS headers list.

### DIFF
--- a/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
+++ b/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
@@ -8,7 +8,7 @@ public final class AddCorsHeadersRule extends Rule {
 
 	public static final String HEADER_NAME_PREFIX_AC = "Access-Control";
 	public static final String HEADER_NAME_PREFIX_ACA = HEADER_NAME_PREFIX_AC + "-Allow";
-	public static final String HEADER_VALUE_ACA_METHODS = "DELETE,GET,HEAD,POST,PUT, OPTIONS";
+	public static final String HEADER_VALUE_ACA_METHODS = "DELETE,GET,HEAD,POST,PUT,OPTIONS";
 
 	public static final String HEADER_NAME_ACA_ORIGIN = HEADER_NAME_PREFIX_ACA + "-Origin";
 	public static final String HEADER_VALUE_ACA_ORIGIN = "*";

--- a/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
+++ b/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
@@ -8,18 +8,24 @@ public final class AddCorsHeadersRule extends Rule {
 
 	public static final String HEADER_NAME_PREFIX_AC = "Access-Control";
 	public static final String HEADER_NAME_PREFIX_ACA = HEADER_NAME_PREFIX_AC + "-Allow";
+	public static final String HEADER_VALUE_ACA_METHODS = "DELETE,GET,HEAD,POST,PUT, OPTIONS";
 
 	public static final String HEADER_NAME_ACA_ORIGIN = HEADER_NAME_PREFIX_ACA + "-Origin";
 	public static final String HEADER_VALUE_ACA_ORIGIN = "*";
+
+	public static final String HEADER_NAME_ACA_HEADERS = HEADER_NAME_PREFIX_ACA  + "-Headers";
 	public static final String HEADER_NAME_ACA_METHODS = HEADER_NAME_PREFIX_ACA + "-Methods";
-	public static final String HEADER_VALUE_ACA_METHODS = "DELETE,GET,HEAD,POST,PUT";
 	public static final String HEADER_NAME_AC_EXPOSE_HEADERS = HEADER_NAME_PREFIX_AC + "-Expose-Headers";
 	public static final String ACA_HEADERS = "Origin, X-Requested-With, Content-Type, Accept, ETag";
 
 	@Override
 	public final String matchAndApply(
-					final String target, final HttpServletRequest request, final HttpServletResponse response) {
+			final String target, final HttpServletRequest request, final HttpServletResponse response) {
+		// NOTE: In order to reply to CORS preflight request with the appropriate CORS headers, ...
+		// ... Access-Control-Allow-Headers should contain the same headers ...
+		// ... as Access-Control-Expose-Headers or more.
 		response.setHeader(HEADER_NAME_AC_EXPOSE_HEADERS, ACA_HEADERS);
+		response.setHeader(HEADER_NAME_ACA_HEADERS, ACA_HEADERS);
 		response.setHeader(HEADER_NAME_ACA_METHODS, HEADER_VALUE_ACA_METHODS);
 		response.setHeader(HEADER_NAME_ACA_ORIGIN, HEADER_VALUE_ACA_ORIGIN);
 		return null;


### PR DESCRIPTION
Related Jira's task: https://mongoose-issues.atlassian.net/browse/BASE-1355
As for 31.03.2019, the task was completed, yet it wasn't working. The problem is: when we're using custom CORS headers (such as "Etag"), the browser sends CORS preflight request. The response to that request should include the same headers as Access-Control-Allow-Headers (or more). 
CORS protocol documentation: https://fetch.spec.whatwg.org/#http-cors-protocol