### PR TITLE
[BASE-1367] Add 'If-Match' header to CORS policy.

### DIFF
--- a/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
+++ b/src/main/java/com/emc/mongoose/base/control/AddCorsHeadersRule.java
@@ -16,7 +16,7 @@ public final class AddCorsHeadersRule extends Rule {
 	public static final String HEADER_NAME_ACA_HEADERS = HEADER_NAME_PREFIX_ACA + "-Headers";
 	public static final String HEADER_NAME_ACA_METHODS = HEADER_NAME_PREFIX_ACA + "-Methods";
 	public static final String HEADER_NAME_AC_EXPOSE_HEADERS = HEADER_NAME_PREFIX_AC + "-Expose-Headers";
-	public static final String ACA_HEADERS = "Origin, X-Requested-With, Content-Type, Accept, ETag";
+	public static final String ACA_HEADERS = "Origin, X-Requested-With, Content-Type, Accept, ETag, If-Match";
 
 	@Override
 	public final String matchAndApply(


### PR DESCRIPTION
While working with Mongoose from the UI, "If-Match" header is being passed to "/run" request in order to check whether the run is active or not. As for now, CORS policy doesn't allow to work with the header.
Related JIRA's task: https://mongoose-issues.atlassian.net/projects/BASE/issues/BASE-1367