### PR TITLE
[BASE-1369] Run ID is generated only once. 

### DIFF
--- a/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
+++ b/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
@@ -39,6 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 
 import org.apache.logging.log4j.Level;
+import org.apache.commons.lang.SerializationUtils;
 import org.eclipse.jetty.http.HttpHeader;
 
 /** @author veronika K. on 08.11.18 */
@@ -204,7 +205,7 @@ public class RunServlet extends HttpServlet {
 					InvalidValueTypeException {
 		final Config configResult;
 		if (defaultsPart == null) {
-			configResult = aggregatedConfigWithArgs;
+			configResult = (Config) SerializationUtils.clone(aggregatedConfigWithArgs);
 		} else {
 			final var configIncoming = configFromPart(defaultsPart, resp, aggregatedConfigWithArgs.schema());
 			// the load step id was set manually if it is set to some non-null/non-empty value in the incoming config

--- a/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
+++ b/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
@@ -100,10 +100,8 @@ public class RunServlet extends HttpServlet {
 			} catch (final RejectedExecutionException e) {
 				resp.setStatus(HttpServletResponse.SC_CONFLICT);
 			}
-		} catch (final IllegalArgumentException illegalScenario) {
-			LogUtil.exception(Level.WARN, illegalScenario, "Failed to run a scenario. Details:", illegalScenario.getMessage());
 		} catch (final NoSuchMethodException | RuntimeException e) {
-			LogUtil.exception(Level.ERROR, e, "Failed to run a scenario with the request {}", req);
+			LogUtil.exception(Level.WARN, e, "Failed to run a scenario with the request {}", req);
 			resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 		}
 	}
@@ -258,16 +256,13 @@ public class RunServlet extends HttpServlet {
 	}
 
 	static String getIncomingScenarioOrDefault(final Part scenarioPart, final Path appHomePath)
-					throws IOException, IllegalArgumentException {
+					throws IOException {
 		final String scenarioResult;
 		if (scenarioPart == null) {
 			scenarioResult = ScenarioUtil.defaultScenario(appHomePath);
 		} else {
 			try (final var br = new BufferedReader(new InputStreamReader(scenarioPart.getInputStream()))) {
 				scenarioResult = br.lines().collect(Collectors.joining("\n"));
-			}
-			if (scenarioResult.trim().replace("\"", "").isEmpty()) {
-				throw new IllegalArgumentException("Empty scenario won't be executed.");
 			}
 		}
 		return scenarioResult;


### PR DESCRIPTION
Mongoose is running on localhost:9999 (let's say it performs run #1), I stopped it by 
 $ curl -v -X DELETE localhost:9999/run (with "If-match" header containing run id)
 Then I ran it again (run #2): 
 $ curl -v -X POST localhost:9999/run
 
 I expected load steps of run #1 and run #2 to have different run IDs.

Related JIRA's task: https://mongoose-issues.atlassian.net/browse/BASE-1369