### PR TITLE
[BASE-1374] Update image version.

### DIFF
--- a/doc/changelog/README.md
+++ b/doc/changelog/README.md
@@ -71,7 +71,7 @@
 
 | Id | Description |
 |----|-------------|
-| [BASE-1366](https://mongoose-issues.atlassian.net/browse/BASE-1366) | Run ID doesn't get exported to Prometheus |
+| [BASE-1366](https://mongoose-issues.atlassian.net/browse/BASE-1366) | Run ID doesn't get exported to Prometheus | 
 | [BASE-1367](https://mongoose-issues.atlassian.net/browse/BASE-1367) | Logs unavailability from browser's HTTP requests |
 | [BASE-1368](https://mongoose-issues.atlassian.net/browse/BASE-1368) | Prometheus exporter failure |
 | [BASE-1369](https://mongoose-issues.atlassian.net/browse/BASE-1369) | Non-unique run ID is generated via starting with REST API |

--- a/doc/changelog/README.md
+++ b/doc/changelog/README.md
@@ -67,6 +67,16 @@
 
 # 4.2.12
 
+## Fixed Bugs
+
+| Id | Description |
+|----|-------------|
+| [BASE-1366](https://mongoose-issues.atlassian.net/browse/BASE-1366) | Run ID doesn't get exported to Prometheus |
+| [BASE-1367](https://mongoose-issues.atlassian.net/browse/BASE-1367) | Logs unavailability from browser's HTTP requests |
+| [BASE-1368](https://mongoose-issues.atlassian.net/browse/BASE-1368) | Prometheus exporter failure |
+| [BASE-1369](https://mongoose-issues.atlassian.net/browse/BASE-1369) | Non-unique run ID is generated via starting with REST API |
+
+
 Add "If-Match" header into CORS policy in order to make run status check via browser available. <br/>
 Fix issue with non-unique run IDs while starting a new run via HTTP.
 

--- a/doc/changelog/README.md
+++ b/doc/changelog/README.md
@@ -76,10 +76,6 @@
 | [BASE-1368](https://mongoose-issues.atlassian.net/browse/BASE-1368) | Prometheus exporter failure |
 | [BASE-1369](https://mongoose-issues.atlassian.net/browse/BASE-1369) | Non-unique run ID is generated via starting with REST API |
 
-
-Add "If-Match" header into CORS policy in order to make run status check via browser available. <br/>
-Fix issue with non-unique run IDs while starting a new run via HTTP.
-
 # 4.2.11
 
 Allow the operation latency be equal to the duration

--- a/doc/changelog/README.md
+++ b/doc/changelog/README.md
@@ -1,6 +1,7 @@
 # Contents
 
 ## 2019
+* [4.2.12](#4212) 2019-06-11
 * [4.2.11](#4211) 2019-05-05
 * [4.2.10](#4210) 2019-04-25
 * [4.2.9](#429) 2019-04-19
@@ -63,6 +64,11 @@
 * [0.1.5](#015) 09/22/14
 * [0.1.4](#014) 09/17/14
 * [0.1.3](#013) 08/15/14
+
+# 4.2.12
+
+Add "If-Match" header into CORS policy in order to make run status check via browser available. <br/>
+Fix issue with non-unique run IDs while starting a new run via HTTP.
 
 # 4.2.11
 

--- a/src/main/resources/config/defaults.yaml
+++ b/src/main/resources/config/defaults.yaml
@@ -82,7 +82,7 @@ run:
   node: false
   port: 9999
   scenario: null
-  version: 4.2.11
+  version: 4.2.12
 
 storage:
   auth:

--- a/src/test/robot/api/remote/data/aggregated_defaults.yaml
+++ b/src/test/robot/api/remote/data/aggregated_defaults.yaml
@@ -52,7 +52,7 @@ run:
   id: 0
   port: 9999
   scenario: null
-  version: "4.2.11"
+  version: "4.2.12"
 storage:
   namespace: null
   driver:

--- a/src/test/robot/api/remote/data/aggregated_defaults_invalid.yaml
+++ b/src/test/robot/api/remote/data/aggregated_defaults_invalid.yaml
@@ -52,7 +52,7 @@ run:
   id: 0
   port: 9999
   scenario: null
-  version: "4.2.11"
+  version: "4.2.12"
 storage:
   net:
     node:


### PR DESCRIPTION
Update current version of mongoose-base image, push the actual image into docker hub.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/BASE/issues/BASE-1374?filter=recentlyviewed&orderby=lastviewed%20DESC