### PR TITLE
[BASE-1376] Mongoose doesn't block the second run

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -91,7 +91,7 @@ build_docker_image:
     - pip install -U requests
     - pip install -U robotframework
     - pip install -U robotframework-requests
-    - pip install -U robotframework-csvlibrary
+    - pip install -U robotframework-csvlib
   script:
     - export MONGOOSE_VERSION=$(cat src/main/resources/config/defaults.yaml | grep version | sed -n 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
     - export MONGOOSE_IMAGE_VERSION=${CI_COMMIT_SHA}

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -84,9 +84,9 @@ build_docker_image:
   variables:
     HOST_WORKING_DIR: ${CI_PROJECT_DIR}
     MONGOOSE_IMAGE_VERSION: ${CI_COMMIT_SHA}
-    PYTHONPATH: ${PYTHONPATH}:/usr/lib/python2.7/site-packages:src/test/robot/lib
+    PYTHONPATH: ${PYTHONPATH}:/usr/lib/python3.8/site-packages:src/test/robot/lib
   before_script:
-    - apk add --no-cache --update python py-pip
+    - apk add --no-cache --update python3 py-pip
     - pip install -U virtualenv
     - pip install -U requests
     - pip install -U robotframework

--- a/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
+++ b/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
@@ -11,7 +11,9 @@ import com.emc.mongoose.base.concurrent.SingleTaskExecutorImpl;
 import com.emc.mongoose.base.config.ConfigFormat;
 import com.emc.mongoose.base.config.ConfigUtil;
 import com.emc.mongoose.base.env.Extension;
+import com.emc.mongoose.base.load.step.LoadStepManagerService;
 import com.emc.mongoose.base.load.step.ScenarioUtil;
+import com.emc.mongoose.base.load.step.service.LoadStepService;
 import com.emc.mongoose.base.logging.LogUtil;
 import com.emc.mongoose.base.logging.Loggers;
 import com.emc.mongoose.base.metrics.MetricsManager;
@@ -23,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,18 +57,21 @@ public class RunServlet extends HttpServlet {
 	private final Config aggregatedConfigWithArgs;
 	private final Path appHomePath;
 	private final SingleTaskExecutor scenarioExecutor = new SingleTaskExecutorImpl();
+	private final LoadStepManagerService scenarioStepSvc;
 
 	public RunServlet(
 					final ClassLoader clsLoader,
 					final List<Extension> extensions,
 					final MetricsManager metricsMgr,
 					final Config aggregatedConfigWithArgs,
-					final Path appHomePath) {
+					final Path appHomePath,
+					final LoadStepManagerService scenarioStepSvc) {
 		this.scriptEngine = ScenarioUtil.scriptEngineByDefault(clsLoader);
 		this.extensions = extensions;
 		this.metricsMgr = metricsMgr;
 		this.aggregatedConfigWithArgs = aggregatedConfigWithArgs;
 		this.appHomePath = appHomePath;
+		this.scenarioStepSvc = scenarioStepSvc;
 	}
 
 	@Override
@@ -107,7 +113,7 @@ public class RunServlet extends HttpServlet {
 	}
 
 	@Override
-	protected final void doHead(final HttpServletRequest req, final HttpServletResponse resp) {
+	protected final void doHead(final HttpServletRequest req, final HttpServletResponse resp) throws RemoteException {
 		applyForActiveRunIfAny(resp, RunServlet::setRunExistsResponse);
 	}
 
@@ -132,12 +138,16 @@ public class RunServlet extends HttpServlet {
 	}
 
 	void applyForActiveRunIfAny(
-					final HttpServletResponse resp, final BiConsumer<Run, HttpServletResponse> action) {
+					final HttpServletResponse resp, final BiConsumer<Run, HttpServletResponse> action) throws RemoteException {
 		final var activeTask = scenarioExecutor.task();
-		if (null == activeTask) {
+		final var activeService = scenarioStepSvc.getStepService();
+		if (null == activeTask && activeService == null) {
 			resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 		} else if (activeTask instanceof Run) {
 			final var activeRun = (Run) activeTask;
+			action.accept(activeRun, resp);
+		} else if (activeService != null) {
+			final var activeRun = new RunImpl("", "",null, activeService.runId());
 			action.accept(activeRun, resp);
 		} else {
 			Loggers.ERR.warn("The scenario executor runs an alien task: {}", activeTask);

--- a/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
+++ b/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
@@ -147,7 +147,7 @@ public class RunServlet extends HttpServlet {
 			final var activeRun = (Run) activeTask;
 			action.accept(activeRun, resp);
 		} else if (activeService != null) {
-			final var activeRun = new RunImpl("", "",null, activeService.runId());
+			final var activeRun = new RunImpl("", "", null, activeService.runId());
 			action.accept(activeRun, resp);
 		} else {
 			Loggers.ERR.warn("The scenario executor runs an alien task: {}", activeTask);

--- a/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
+++ b/src/main/java/com/emc/mongoose/base/control/run/RunServlet.java
@@ -77,7 +77,10 @@ public class RunServlet extends HttpServlet {
 	@Override
 	protected final void doPost(final HttpServletRequest req, final HttpServletResponse resp)
 					throws IOException, ServletException {
-
+		if (scenarioStepSvc.getStepService() != null) {
+			resp.setStatus(HttpServletResponse.SC_CONFLICT);
+			return;
+		}
 		final Part defaultsPart;
 		final Part scenarioPart;
 		final var contentTypeHeaderValue = req.getHeader(HttpHeader.CONTENT_TYPE.toString());

--- a/src/main/java/com/emc/mongoose/base/load/step/LoadStepManagerService.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/LoadStepManagerService.java
@@ -1,5 +1,6 @@
 package com.emc.mongoose.base.load.step;
 
+import com.emc.mongoose.base.load.step.service.LoadStepService;
 import com.emc.mongoose.base.svc.Service;
 import com.github.akurilov.confuse.Config;
 import java.rmi.RemoteException;
@@ -9,6 +10,8 @@ public interface LoadStepManagerService extends Service {
 
 	String SVC_NAME = "load/step/manager";
 
-	String getStepService(final String stepType, final Config config, final List<Config> ctxConfigs)
+	String newStepService(final String stepType, final Config config, final List<Config> ctxConfigs)
 					throws RemoteException;
+
+	LoadStepService getStepService() throws RemoteException;
 }

--- a/src/main/java/com/emc/mongoose/base/load/step/client/LoadStepSliceUtil.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/client/LoadStepSliceUtil.java
@@ -41,7 +41,7 @@ public interface LoadStepSliceUtil {
 
 		final String stepSvcName;
 		try {
-			stepSvcName = stepMgrSvc.getStepService(stepTypeName, configSlice, ctxConfigs);
+			stepSvcName = stepMgrSvc.newStepService(stepTypeName, configSlice, ctxConfigs);
 		} catch (final Exception e) {
 			throwUncheckedIfInterrupted(e);
 			LogUtil.exception(

--- a/src/main/java/com/emc/mongoose/base/load/step/service/LoadStepManagerServiceImpl.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/service/LoadStepManagerServiceImpl.java
@@ -18,6 +18,7 @@ public final class LoadStepManagerServiceImpl extends ServiceBase
 
 	private final List<Extension> extensions;
 	private final MetricsManager metricsMgr;
+	private LoadStepService stepSvc = null;
 
 	public LoadStepManagerServiceImpl(
 					final int port, final List<Extension> extensions, final MetricsManager metricsMgr) {
@@ -44,10 +45,15 @@ public final class LoadStepManagerServiceImpl extends ServiceBase
 	}
 
 	@Override
-	public final String getStepService(
-					final String stepType, final Config config, final List<Config> ctxConfigs)
-					throws RemoteException {
-		final LoadStepService stepSvc = new LoadStepServiceImpl(port, extensions, stepType, config, ctxConfigs, metricsMgr);
+	public final LoadStepService getStepService() {
+		return stepSvc;
+	}
+
+	@Override
+	public final String newStepService(
+			final String stepType, final Config config, final List<Config> ctxConfigs)
+			throws RemoteException {
+		stepSvc = new LoadStepServiceImpl(port, extensions, stepType, config, ctxConfigs, metricsMgr);
 		Loggers.MSG.info("New step service started @ port #{}: {}", port, stepSvc.name());
 		return stepSvc.name();
 	}


### PR DESCRIPTION
**Issue:**
There are mong1(entry) + mong2(add)
1) after staring scenario HEAD request from mong1 returns `200 OK` (okey) and from mong2 returns `204 No Content` (not okey, must be 200)
2)  after staring scenario POST request from mong1 returns `409 Conflict` (okey) and from mong2 returns `202 Accepted` (not okey, must be blocked) and start new parallel LoadStep on mong2

When a mongoose starts on a POST request, an new service executor is tracked in RunServelt. When a start occurs via RMI, RunServlet does not know about running executers and cannot block new POST requests. 

---
**Solution:**
Instance of LoadStepManagerService has been added to RunServlet to track services started via RMI.