### PR TITLE
Fix CI/CD

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -91,7 +91,7 @@ build_docker_image:
     - pip install -U requests
     - pip install -U robotframework
     - pip install -U robotframework-requests
-    - pip install -U robotframework-csvlibrary
+    - pip install -U robotframework-csvlib
   script:
     - export MONGOOSE_VERSION=$(cat src/main/resources/config/defaults.yaml | grep version | sed -n 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
     - export MONGOOSE_IMAGE_VERSION=${CI_COMMIT_SHA}

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -84,9 +84,9 @@ build_docker_image:
   variables:
     HOST_WORKING_DIR: ${CI_PROJECT_DIR}
     MONGOOSE_IMAGE_VERSION: ${CI_COMMIT_SHA}
-    PYTHONPATH: ${PYTHONPATH}:/usr/lib/python2.7/site-packages:src/test/robot/lib
+    PYTHONPATH: ${PYTHONPATH}:/usr/lib/python3.8/site-packages:src/test/robot/lib
   before_script:
-    - apk add --no-cache --update python py-pip
+    - apk add --no-cache --update python3 py-pip
     - pip install -U virtualenv
     - pip install -U requests
     - pip install -U robotframework


### PR DESCRIPTION
`docker:stable` was updated day ago. Now it uses `alpine 3.12v`, which doesn't include `python2`