### PR TITLE
[BASE-1413] Fix worker after-test data aggregation

### DIFF
--- a/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
@@ -55,11 +55,13 @@ public class FileManagerImpl implements FileManager {
 			final int buffSize = (int) Math.min(REUSABLE_BUFF_SIZE_MAX, remainingSize);
 			if (buffSize > 0) {
 				final ByteBuffer bb = ByteBuffer.allocate(buffSize);
+				int doneSize = 0;
 				int readBytesTotal;
 				int newLineCharacterCode = '\n';  //  == 10
-				byte[] resultingBuffer;
+				byte[] resultingBuffer = new byte[0];
+				while (doneSize < buffSize) {
 					readBytesTotal = fileChannel.read(bb);
-					int lastReadItemIndex = readBytesTotal-1;
+					int lastReadItemIndex = readBytesTotal - 1;
 					if (readBytesTotal < 0) {
 						// unexpected but possible: the file is shorter than was estimated before
 						final byte[] buff = new byte[bb.position()];
@@ -71,12 +73,15 @@ public class FileManagerImpl implements FileManager {
 						while (bb.get(lastNewLineCharacterIndex) != newLineCharacterCode) {
 							lastNewLineCharacterIndex--;
 						}
-						resultingBuffer = new byte[lastNewLineCharacterIndex+1];
+						resultingBuffer = new byte[lastNewLineCharacterIndex + 1];
 						bb.rewind();
-						bb.get(resultingBuffer,0,lastNewLineCharacterIndex+1);
+						bb.get(resultingBuffer, 0, lastNewLineCharacterIndex + 1);
+						doneSize += readBytesTotal;
 					} else {
 						resultingBuffer = bb.array();
+						doneSize += readBytesTotal;
 					}
+				}
 				return resultingBuffer;
 			} else {
 				return EMPTY;

--- a/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
@@ -55,21 +55,29 @@ public class FileManagerImpl implements FileManager {
 			final int buffSize = (int) Math.min(REUSABLE_BUFF_SIZE_MAX, remainingSize);
 			if (buffSize > 0) {
 				final ByteBuffer bb = ByteBuffer.allocate(buffSize);
-				int doneSize = 0;
-				int n;
-				while (doneSize < buffSize) {
-					n = fileChannel.read(bb);
-					if (n < 0) {
+				int readBytesTotal;
+				int newLineCharacterCode = '\n';  //  == 10
+				byte[] resultingBuffer;
+					readBytesTotal = fileChannel.read(bb);
+					int lastReadItemIndex = readBytesTotal-1;
+					if (readBytesTotal < 0) {
 						// unexpected but possible: the file is shorter than was estimated before
 						final byte[] buff = new byte[bb.position()];
 						bb.rewind();
 						bb.get(buff);
 						return buff;
+					} else if (bb.get(lastReadItemIndex) != newLineCharacterCode) {
+						int lastNewLineCharacterIndex = lastReadItemIndex;
+						while (bb.get(lastNewLineCharacterIndex) != newLineCharacterCode) {
+							lastNewLineCharacterIndex--;
+						}
+						resultingBuffer = new byte[lastNewLineCharacterIndex+1];
+						bb.rewind();
+						bb.get(resultingBuffer,0,lastNewLineCharacterIndex+1);
 					} else {
-						doneSize += n;
+						resultingBuffer = bb.array();
 					}
-				}
-				return bb.array();
+				return resultingBuffer;
 			} else {
 				return EMPTY;
 			}

--- a/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
+++ b/src/main/java/com/emc/mongoose/base/load/step/file/FileManagerImpl.java
@@ -57,11 +57,11 @@ public class FileManagerImpl implements FileManager {
 				final ByteBuffer bb = ByteBuffer.allocate(buffSize);
 				int doneSize = 0;
 				int readBytesTotal;
-				int newLineCharacterCode = '\n';  //  == 10
+				final int newLineCharacterCode = '\n';  //  == 10
 				byte[] resultingBuffer = new byte[0];
 				while (doneSize < buffSize) {
 					readBytesTotal = fileChannel.read(bb);
-					int lastReadItemIndex = readBytesTotal - 1;
+					final int lastReadItemIndex = readBytesTotal - 1;
 					if (readBytesTotal < 0) {
 						// unexpected but possible: the file is shorter than was estimated before
 						final byte[] buff = new byte[bb.position()];
@@ -76,6 +76,10 @@ public class FileManagerImpl implements FileManager {
 						resultingBuffer = new byte[lastNewLineCharacterIndex + 1];
 						bb.rewind();
 						bb.get(resultingBuffer, 0, lastNewLineCharacterIndex + 1);
+						// we add readBytesTotal to doneSize as we consider all the read bytes handled in spite of
+						// rejecting part of the ByteBuffer. doneSize is only needed to finish the while loop. And the
+						// position for the next readFromFile() is set via offset which is determined by the size of
+						// the resultingBuffer.
 						doneSize += readBytesTotal;
 					} else {
 						resultingBuffer = bb.array();


### PR DESCRIPTION
General description
So the issue that we had is that when distributed mode finishes it aggregates data from local temporary files from worker nodes. It happens when --item-output-file or --output-metrics-trace-persist are specified (or both). We read it by 16Mb chunks (if there is enough data) and we synchronously put it in the local aggregated file. But we aggregate data in parallel, so when one chunk is read from worker and written into local file, we release the lock and another thread appends to previous file. But 16Mb chunk isn't guaranteed to finish at the end of the line.

Resolution:
After we've read the chunk, we check whether we stopped at a newline character. If we didn't we iterate through the ByteBuffer until we reach \n character and then copy it to a byte[] array that is a return value.

Also I'd like to notice that I've first removed the while loop from the method as it doesn't make any sense, because we get the chunk of the necessary size from the first try. But then I've put it back since maybe it's needed in case of network instability.

Possible spot for improvement:
ultimately we would want to just create a slice(0, lastNewLineCharacterIndex). But this is introduced only in Java 13.