### PR TITLE
add buffer pre allocation for item input

### DIFF
--- a/src/main/resources/config/defaults.yaml
+++ b/src/main/resources/config/defaults.yaml
@@ -89,7 +89,7 @@ run:
   node: false
   port: 9999
   scenario: null
-  version: 4.3.0
+  version: 4.3.1
 
 storage:
   auth:


### PR DESCRIPTION
This shows improvement +40000 op/s on small reads on ssd drives. Previously we allocated new space for items each time we asked for new items. When we do reads we ask for a batch of them, but we only get 1 item when we do file listing. So we were wasting loots of memory as well as doing ~ 80.000 new calls each second. 

The lock is required as different threads ask for new items, so w/o it we could end up in situation where one threads asks for more items after clearing up buffer for itself, while another one tries to convert items into ops.