### PR TITLE
Updating Gradle for Multi-Release JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,6 +327,7 @@ jar {
 			"Main-Class": mainClass,
 			"Implementation-Title": project.description,
 			"Implementation-Version": project.version,
+			"Multi-Release": "true",
 		)
 	}
 	provided3rdPartyClasses.each {


### PR DESCRIPTION
The latest log4j is printing the following warning:
"WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance."
Adding multi-release=true to the Gradle JAR manifest per https://blog.gradle.org/mrjars